### PR TITLE
Add __repr__() function to model classes

### DIFF
--- a/src/showingpreviously/model.py
+++ b/src/showingpreviously/model.py
@@ -5,6 +5,9 @@ class Chain:
     def __init__(self, name: str) -> None:
         self.name = name
 
+    def __repr__(self) -> str:
+        return f'Chain "{self.name}"'
+
 
 class Cinema:
     def __init__(self, name: str, timezone: str, started_archiving: datetime) -> None:
@@ -12,16 +15,25 @@ class Cinema:
         self.timezone = timezone
         self.started_archiving = started_archiving
 
+    def __repr__(self) -> str:
+        return f'Cinema "{self.name}"'
+
 
 class Screen:
     def __init__(self, name: str) -> None:
         self.name = name
+
+    def __repr__(self) -> str:
+        return f'Screen "{self.name}"'
 
 
 class Film:
     def __init__(self, name: str, year: str) -> None:
         self.name = name
         self.year = year
+
+    def __repr__(self) -> str:
+        return f'Film "{self.name}" ({self.year})'
 
 
 class Showing:
@@ -33,6 +45,9 @@ class Showing:
         self.cinema = cinema
         self.screen = screen
         self.json_attributes = json_attributes
+
+    def __repr__(self) -> str:
+        return f'Showing of {self.film} at {self.chain}, {self.cinema}, {self.screen}, on {self.time.strftime("%Y-%m-%d %H:%M")}'
 
 
 class ChainArchiver:


### PR DESCRIPTION
Add the `__repr__()` function to the classes in the model, to enable prettier printing. This means that a showing object can be printed in a useful way, replacing the (non-helpful) `<main.Showing object at 0x7f49e3a00940>` with `Showing of Film "The Ancient Woods" (2017) at Chain "Centre for the Moving Image", Cinema "Filmhouse Belmont", Screen "BEL2", on 2021-10-27 15:45`.

Only the necessary attributes of each class are printed. This means, for example, that the `timezone` of a `Cinema` object is left out, as is the `json_attributes` of a showing. This was deliberate to avoid overly-long strings.