### PR TITLE
Add cinema: Centre for the Moving Image (Filmhouse Edinburgh and Belmont Filmhouse)

### DIFF
--- a/ATTRIBUTES.md
+++ b/ATTRIBUTES.md
@@ -5,9 +5,13 @@ that add some extra information about that showing. All JSON attributes are opti
 exposes that information, they are used.
 
 The following attributes are used:
-- `language`: string, specifies the language of the showing
-- `captioned`: string or bool, specifies if the film is captioned. If the language of the captioning is known, this is 
+- `audio-described`: string or bool, specifies if the film can be viewed with an audio description (usually through an
+additional device provided by the cinema). If the language of the audio description is known, this is the string 
+language (eg. `english`), and if not, this is simply `True`
+- `captioned`: string or bool, specifies if the film is captioned. If the language of the captioning is known, this is
 the string language (eg. `english`), and if not, this is simply `True`
-- `subtitled`: string or bool, specifies if the film is subtitled. If the language of the subtitling is known, this is 
-the string language (eg. `english`), and if not, this is simply `True`
+- `format`: specifies the format the film was projected in
+- `language`: string, specifies the language(s) of the showing
 - `senior`: specifies if this showing is for senior citizens only
+- `subtitled`: string or bool, specifies if the film is subtitled. If the language of the subtitling is known, this is
+the string language (eg. `english`), and if not, this is simply `True`

--- a/ATTRIBUTES.md
+++ b/ATTRIBUTES.md
@@ -8,6 +8,7 @@ The following attributes are used:
 - `audio-described`: string or bool, specifies if the film can be viewed with an audio description (usually through an
 additional device provided by the cinema). If the language of the audio description is known, this is the string 
 language (eg. `english`), and if not, this is simply `True`
+- `carers-and-babies`: bool, specifies if this showing is for babies and their carers only
 - `captioned`: string or bool, specifies if the film is captioned. If the language of the captioning is known, this is
 the string language (eg. `english`), and if not, this is simply `True`
 - `format`: specifies the format the film was projected in
@@ -15,3 +16,4 @@ the string language (eg. `english`), and if not, this is simply `True`
 - `senior`: specifies if this showing is for senior citizens only
 - `subtitled`: string or bool, specifies if the film is subtitled. If the language of the subtitling is known, this is
 the string language (eg. `english`), and if not, this is simply `True`
+

--- a/README.md
+++ b/README.md
@@ -11,4 +11,6 @@ Installing this module will install the `showingpreviously` command. This has tw
 2. `showingpreviously run`: Runs the archiver against all cinemas
 
 ## Supported Cinemas
+- [Centre for the Moving Image (Filmhouse Edinburgh and Filmhouse Belmont)](https://www.cmi-scotland.co.uk/) (added 2021-10-30)
 - [Dundee Contemporary Arts Cinema](https://www.dca.org.uk/whats-on/films) (added 2021-10-29)
+

--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ Installing this module will install the `showingpreviously` command. This has tw
 2. `showingpreviously run`: Runs the archiver against all cinemas
 
 ## Supported Cinemas
-- [Centre for the Moving Image (Filmhouse Edinburgh and Filmhouse Belmont)](https://www.cmi-scotland.co.uk/) (added 2021-10-30)
+- [Centre for the Moving Image](https://www.cmi-scotland.co.uk/) ([Filmhouse Edinburgh](https://www.filmhousecinema.com/) and [Belmont Filmhouse](https://www.belmontfilmhouse.com/)) (added 2021-10-30)
 - [Dundee Contemporary Arts Cinema](https://www.dca.org.uk/whats-on/films) (added 2021-10-29)
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as f:
 
 setup(
     name = 'showingpreviously',
-    version = '0.2.1',
+    version = '0.2.2',
     description = 'An archiver of cinema movie showtimes',
     long_description = long_description,
     long_description_content_type = 'text/markdown',

--- a/src/showingpreviously/archiver.py
+++ b/src/showingpreviously/archiver.py
@@ -4,10 +4,12 @@ from showingpreviously.db import add_chain, add_cinema, add_screen, add_film, ad
 from showingpreviously.model import Showing, Chain
 
 # import cinemas here, and add them to the all_cinema_chains list
+from showingpreviously.cinemas.centre_for_the_moving_image import CentreForTheMovingImage
 from showingpreviously.cinemas.dundee_contemporary_arts import DundeeContemporaryArts
 
 all_cinema_chains = [
-    DundeeContemporaryArts(),
+    CentreForTheMovingImage(),
+#    DundeeContemporaryArts(),
 ]
 
 

--- a/src/showingpreviously/archiver.py
+++ b/src/showingpreviously/archiver.py
@@ -4,10 +4,12 @@ from showingpreviously.db import add_chain, add_cinema, add_screen, add_film, ad
 from showingpreviously.model import Showing
 
 # import cinemas here, and add them to the all_cinema_chains list
+from showingpreviously.cinemas.centre_for_the_moving_image import CentreForTheMovingImage
 from showingpreviously.cinemas.dundee_contemporary_arts import DundeeContemporaryArts
 
 all_cinema_chains = [
-    DundeeContemporaryArts(),
+    CentreForTheMovingImage(),
+#    DundeeContemporaryArts(),
 ]
 
 

--- a/src/showingpreviously/archiver.py
+++ b/src/showingpreviously/archiver.py
@@ -1,7 +1,7 @@
 import pytz
 
 from showingpreviously.db import add_chain, add_cinema, add_screen, add_film, add_showing
-from showingpreviously.model import Showing
+from showingpreviously.model import Showing, Chain
 
 # import cinemas here, and add them to the all_cinema_chains list
 from showingpreviously.cinemas.dundee_contemporary_arts import DundeeContemporaryArts
@@ -29,8 +29,18 @@ def process_showing(showing: Showing):
     add_showing(film.name, film.year, chain.name, cinema.name, screen.name, utc_time, json_attributes)
 
 
+def run_chain(chain: Chain):
+    showings = chain.get_showings()
+    for showing in showings:
+        process_showing(showing)
+
+
 def run_all() -> None:
     for cinema_chain in all_cinema_chains:
-        showings = cinema_chain.get_showings()
-        for showing in showings:
-            process_showing(showing)
+        run_chain(cinema_chain)
+
+
+def run_single(name: str) -> None:
+    for cinema_chain in all_cinema_chains:
+        if type(cinema_chain).__name__ == name:
+            run_chain(cinema_chain)

--- a/src/showingpreviously/archiver.py
+++ b/src/showingpreviously/archiver.py
@@ -9,7 +9,7 @@ from showingpreviously.cinemas.dundee_contemporary_arts import DundeeContemporar
 
 all_cinema_chains = [
     CentreForTheMovingImage(),
-#    DundeeContemporaryArts(),
+    DundeeContemporaryArts(),
 ]
 
 

--- a/src/showingpreviously/cinemas/centre_for_the_moving_image.py
+++ b/src/showingpreviously/cinemas/centre_for_the_moving_image.py
@@ -63,15 +63,17 @@ def get_showing_item(cinema: dict[str, any], showing_date_str: str, showing_item
     release_year, attributes = get_film_page_details(cinema, more_info_link)
     showing_times = showing_item.find('div', class_='screening-times-btns')
     film = Film(name=name, year=release_year)
+    if film.name.lower().endswith(' (baby + carer)'):
+        film.name = film.name[:-len(' (baby + carer)')]
+        attributes['carers-and-babies'] = True
+    if film.name.lower().startswith('senior selections: '):
+        film.name = film.name[len('senior selections: '):]
+        attributes['seniors'] = True
     for showing_time in showing_times.find_all('a', class_='btn-times'):
         showing_time_str = showing_time.text.strip().split('\n')[0]
         showing_datetime = datetime.datetime.strptime(f'{showing_date_str} {showing_time_str}', '%Y-%m-%d %H:%M')
         showing_screen = Screen(name=showing_time.find('span', class_='screen').text)
         showing_type_attributes = get_showing_type_attributes(name, showing_date_str, showing_time)
-        if ' (Baby + Carer)' in film.name:
-            film.name = film.name[:-len(' (Baby + Carer)')]
-            if 'carers-and-babies' not in showing_type_attributes:
-                showing_type_attributes['carers-and-babies'] = True
         showing = Showing(
             film=film,
             time=showing_datetime,

--- a/src/showingpreviously/cinemas/centre_for_the_moving_image.py
+++ b/src/showingpreviously/cinemas/centre_for_the_moving_image.py
@@ -16,7 +16,8 @@ BELMONT_CINEMA = Cinema(name='Belmont Filmhouse', timezone='Europe/London')
 KNOWN_SHOWING_TYPE_ATTRIBUTES = [
     'audio-described',
     'subtitled',
-    'captioned'
+    'captioned',
+    'carers-and-babies',
 ]
 
 
@@ -67,6 +68,10 @@ def get_showing_item(cinema: dict[str, any], showing_date_str: str, showing_item
         showing_datetime = datetime.datetime.strptime(f'{showing_date_str} {showing_time_str}', '%Y-%m-%d %H:%M')
         showing_screen = Screen(name=showing_time.find('span', class_='screen').text)
         showing_type_attributes = get_showing_type_attributes(name, showing_date_str, showing_time)
+        if ' (Baby + Carer)' in film.name:
+            film.name = film.name[:-len(' (Baby + Carer)')]
+            if 'carers-and-babies' not in showing_type_attributes:
+                showing_type_attributes['carers-and-babies'] = True
         showing = Showing(
             film=film,
             time=showing_datetime,

--- a/src/showingpreviously/cinemas/centre_for_the_moving_image.py
+++ b/src/showingpreviously/cinemas/centre_for_the_moving_image.py
@@ -18,6 +18,7 @@ KNOWN_SHOWING_TYPE_ATTRIBUTES = [
     'subtitled',
     'captioned',
     'carers-and-babies',
+    'three-d',
 ]
 
 
@@ -76,6 +77,12 @@ def get_showing_item(cinema: dict[str, any], showing_date_str: str, showing_item
             continue
         showing_datetime = datetime.datetime.strptime(f'{showing_date_str} {showing_time_str}', '%Y-%m-%d %H:%M')
         showing_type_attributes = get_showing_type_attributes(name, showing_date_str, showing_time)
+        # Special case for 3D screenings, which should be treated as a format and not as a separate attribute
+        if 'three-d' in showing_type_attributes:
+            if 'format' not in attributes:
+                attributes['format'] = []
+            attributes['format'].append('3d')
+            del showing_type_attributes['three-d']
         showing = Showing(
             film=film,
             time=showing_datetime,

--- a/src/showingpreviously/cinemas/centre_for_the_moving_image.py
+++ b/src/showingpreviously/cinemas/centre_for_the_moving_image.py
@@ -11,7 +11,7 @@ DAYS_PREVIOUS = 3
 
 CHAIN = Chain(name='Centre for the Moving Image')
 EDINBURGH_CINEMA = Cinema(name='Filmhouse Edinburgh', timezone='Europe/London')
-BELMONT_CINEMA = Cinema(name='Filmhouse Belmont', timezone='Europe/London')
+BELMONT_CINEMA = Cinema(name='Belmont Filmhouse', timezone='Europe/London')
 
 
 KNOWN_SHOWING_TYPE_ATTRIBUTES = [

--- a/src/showingpreviously/cinemas/centre_for_the_moving_image.py
+++ b/src/showingpreviously/cinemas/centre_for_the_moving_image.py
@@ -100,10 +100,12 @@ def get_film_page_details(cinema: dict[str, any], film_url: str) -> (str, dict[s
     if film_url in film_page_details_cache:
         film_details = film_page_details_cache[film_url]
         return film_details
-    req = get_response(film_url)
+    req = requests.get(film_url)
+    if req.status_code not in [200, 403]:
+        raise CinemaArchiverException(f'Got status code {req.status_code} when fetching URL {film_url}')
     soup = BeautifulSoup(req.text, features='html.parser')
     page_title = soup.find('title').text
-    if 'Access Denied' in page_title:
+    if req.status_code == 403 or 'Access Denied' in page_title:
         return '', {}
     attributes = {}
     details_list = soup.find('div', class_='event-detail')

--- a/src/showingpreviously/cinemas/centre_for_the_moving_image.py
+++ b/src/showingpreviously/cinemas/centre_for_the_moving_image.py
@@ -112,13 +112,13 @@ def get_film_page_details(cinema: dict[str, any], film_url: str) -> (str, dict[s
         raise CinemaArchiverException(f'Got status code {req.status_code} when fetching URL {film_url}')
     soup = BeautifulSoup(req.text, features='html.parser')
     page_title = soup.find('title').text
-    if req.status_code == 403 or 'Access Denied' in page_title:
-        return '', {}
+    release_year = ''
     attributes = {}
-    details_list = soup.find('div', class_='event-detail')
-    release_year = get_specific_film_attribute(details_list, 'release_year')
-    attributes['language'] = get_specific_film_attribute(details_list, 'languages')
-    attributes['format'] = get_specific_film_attribute(details_list, 'format')
+    if req.status_code != 403 and 'Access Denied' not in page_title:
+        details_list = soup.find('div', class_='event-detail')
+        release_year = get_specific_film_attribute(details_list, 'release_year')
+        attributes['language'] = get_specific_film_attribute(details_list, 'languages')
+        attributes['format'] = get_specific_film_attribute(details_list, 'format')
     film_page_details_cache[film_url] = (release_year, attributes)
     return release_year, attributes
 

--- a/src/showingpreviously/cinemas/centre_for_the_moving_image.py
+++ b/src/showingpreviously/cinemas/centre_for_the_moving_image.py
@@ -29,7 +29,6 @@ CINEMAS_LIST = [
 
 film_page_details_cache = {}
 
-
 def get_response(url: str) -> requests.Response:
     r = requests.get(url)
     if r.status_code != 200:
@@ -70,9 +69,12 @@ def get_showing_item(cinema: dict[str, any], showing_date_str: str, showing_item
         film.name = film.name[len('senior selections: '):]
         attributes['seniors'] = True
     for showing_time in showing_times.find_all('a', class_='btn-times'):
-        showing_time_str = showing_time.text.strip().split('\n')[0]
+        showing_time_str = showing_time.text.strip().split('\n')[0].strip()
+        showing_screen = Screen(name=showing_time.find('span', class_='screen').text.strip())
+        if showing_time_str == 'Watch Now' or showing_screen.name == 'On Demand':
+            # Do not include On-Demand showings (through the Filmhouse at Home streaming service)
+            continue
         showing_datetime = datetime.datetime.strptime(f'{showing_date_str} {showing_time_str}', '%Y-%m-%d %H:%M')
-        showing_screen = Screen(name=showing_time.find('span', class_='screen').text)
         showing_type_attributes = get_showing_type_attributes(name, showing_date_str, showing_time)
         showing = Showing(
             film=film,

--- a/src/showingpreviously/cinemas/centre_for_the_moving_image.py
+++ b/src/showingpreviously/cinemas/centre_for_the_moving_image.py
@@ -1,0 +1,134 @@
+from showingpreviously.model import ChainArchiver, CinemaArchiverException, Chain, Cinema, Screen, Film, Showing
+import showingpreviously.requests as requests
+
+import datetime
+from bs4 import BeautifulSoup
+from typing import Iterator, Tuple
+
+
+DAYS_PREVIOUS = 3
+
+
+CHAIN = Chain(name='Centre for the Moving Image')
+EDINBURGH_CINEMA = Cinema(name='Filmhouse Edinburgh', timezone='Europe/London')
+BELMONT_CINEMA = Cinema(name='Filmhouse Belmont', timezone='Europe/London')
+
+
+KNOWN_SHOWING_TYPE_ATTRIBUTES = [
+    'audio-described',
+    'subtitled',
+    'captioned'
+]
+
+
+CINEMAS_LIST = [
+    {'base_url': 'https://www.filmhousecinema.com', 'cinema': EDINBURGH_CINEMA},
+    {'base_url': 'https://www.belmontfilmhouse.com', 'cinema': BELMONT_CINEMA},
+]
+
+
+film_page_details_cache = {}
+
+
+def get_response(url: str) -> requests.Response:
+    r = requests.get(url)
+    if r.status_code != 200:
+        raise CinemaArchiverException(f'Got status code {r.status_code} when fetching URL {url}')
+    return r
+
+
+def get_days_to_fetch() -> [datetime.datetime]:
+    # Fetch films from the range of (today - DAYS_PREVIOUS) to today
+    base = datetime.date.today()
+    date_list = [base - datetime.timedelta(days=x) for x in range(DAYS_PREVIOUS)]
+    return date_list
+
+
+def get_showings_for_date(cinema: dict[str, any], fetch_date: datetime.datetime) -> [Showing]:
+    showings = []
+    fetch_date_str = fetch_date.strftime('%Y-%m-%d')
+    whats_on_url = f'{cinema["base_url"]}/whats-on/{fetch_date_str}'
+    req = get_response(whats_on_url)
+    soup = BeautifulSoup(req.text, features='html.parser')
+    showings_class = soup.find('div', class_='whats-on-list')
+    for showing_item in showings_class.find_all('div', class_='stub-details'):
+        showings += get_showing_item(cinema, fetch_date_str, showing_item)
+    return showings
+
+
+def get_showing_item(cinema: dict[str, any], showing_date_str: str, showing_item: BeautifulSoup) -> [Showing]:
+    showing_list = []
+    name = showing_item.find('span', class_='field--name-title').text
+    more_info_link = showing_item.find('a', class_='btn-more-info')['href']
+    release_year, attributes = get_film_page_details(cinema, more_info_link)
+    showing_times = showing_item.find('div', class_='screening-times-btns')
+    film = Film(name=name, year=release_year)
+    for showing_time in showing_times.find_all('a', class_='btn-times'):
+        showing_time_str = showing_time.text.strip().split('\n')[0].strip()
+        showing_datetime = datetime.datetime.strptime(f'{showing_date_str} {showing_time_str}', '%Y-%m-%d %H:%M')
+        showing_screen = Screen(name=showing_time.find('span', class_='screen').text.strip())
+        showing_type_attributes = get_showing_type_attributes(name, showing_date_str, showing_time)
+        showing = Showing(
+            film = film,
+            time = showing_datetime,
+            chain = CHAIN,
+            cinema = cinema['cinema'],
+            screen = showing_screen,
+            json_attributes = {**attributes, **showing_type_attributes}
+        )
+        showing_list.append(showing)
+    return showing_list
+
+
+def get_showing_type_attributes(film_name: str, showing_date_str: str, showing: BeautifulSoup) -> dict[str, any]:
+    showing_type_list = showing.find_all('span', class_='showing-type')
+    attributes = {}
+    for showing_type in showing_type_list:
+        showing_type_attribute = [attr for attr in showing_type['class'] if attr != 'showing-type']
+        if len(showing_type_attribute) != 1:
+            raise CinemaArchiverException('Expected one showing type attribute for {film_name} on {showing_date_str}: {str(showing_type_attribute)}')
+        showing_type_attribute = showing_type_attribute[0]
+        if showing_type_attribute not in KNOWN_SHOWING_TYPE_ATTRIBUTES:
+            raise CinemaArchiverException('Unknown showing type attribute for {film_name} on {showing_date_str}: {showing_type_attribute}')
+        attributes[showing_type_attribute] = True
+    return attributes
+
+
+def get_film_page_details(cinema: dict[str, any], film_url: str) -> (str, dict[str, any]):
+    global film_page_details_cache
+    if not film_url.startswith('http'):
+        film_url = f'{cinema["base_url"]}{film_url}'
+    if film_url in film_page_details_cache:
+        film_details = film_page_details_cache[film_url]
+        return film_details
+    req = get_response(film_url)
+    soup = BeautifulSoup(req.text, features='html.parser')
+    page_title = soup.find('title').text
+    if 'Access Denied' in page_title:
+        return ('', {})
+    attributes = {}
+    details_list = soup.find('div', class_='event-detail')
+    release_year = get_specific_film_attribute(details_list, 'release_year')
+    attributes['language'] = get_specific_film_attribute(details_list, 'languages')
+    attributes['format'] = get_specific_film_attribute(details_list, 'format')
+    film_page_details_cache[film_url] = (release_year, attributes)
+    return (release_year, attributes)
+
+
+def get_specific_film_attribute(details_list: BeautifulSoup, attribute_name: str) -> str:
+    attribute_soup = details_list.find('li', class_=attribute_name)
+    if attribute_soup == None:
+        return ""
+    attribute_value = attribute_soup.find('p').text.strip().lower()
+    return attribute_value
+
+
+class CentreForTheMovingImage(ChainArchiver):
+    def get_showings(self) -> [Showing]:
+        global film_page_details_cache
+        film_page_details_cache = {}
+        showings = []
+        for cinema in CINEMAS_LIST:
+            for fetch_date in get_days_to_fetch():
+                showings += get_showings_for_date(cinema, fetch_date)
+        return showings

--- a/src/showingpreviously/cinemas/centre_for_the_moving_image.py
+++ b/src/showingpreviously/cinemas/centre_for_the_moving_image.py
@@ -3,7 +3,6 @@ import showingpreviously.requests as requests
 
 import datetime
 from bs4 import BeautifulSoup
-from typing import Iterator, Tuple
 
 
 DAYS_PREVIOUS = 3
@@ -64,17 +63,17 @@ def get_showing_item(cinema: dict[str, any], showing_date_str: str, showing_item
     showing_times = showing_item.find('div', class_='screening-times-btns')
     film = Film(name=name, year=release_year)
     for showing_time in showing_times.find_all('a', class_='btn-times'):
-        showing_time_str = showing_time.text.strip().split('\n')[0].strip()
+        showing_time_str = showing_time.text.strip().split('\n')[0]
         showing_datetime = datetime.datetime.strptime(f'{showing_date_str} {showing_time_str}', '%Y-%m-%d %H:%M')
-        showing_screen = Screen(name=showing_time.find('span', class_='screen').text.strip())
+        showing_screen = Screen(name=showing_time.find('span', class_='screen').text)
         showing_type_attributes = get_showing_type_attributes(name, showing_date_str, showing_time)
         showing = Showing(
-            film = film,
-            time = showing_datetime,
-            chain = CHAIN,
-            cinema = cinema['cinema'],
-            screen = showing_screen,
-            json_attributes = {**attributes, **showing_type_attributes}
+            film=film,
+            time=showing_datetime,
+            chain=CHAIN,
+            cinema=cinema['cinema'],
+            screen=showing_screen,
+            json_attributes={**attributes, **showing_type_attributes}
         )
         showing_list.append(showing)
     return showing_list
@@ -105,20 +104,20 @@ def get_film_page_details(cinema: dict[str, any], film_url: str) -> (str, dict[s
     soup = BeautifulSoup(req.text, features='html.parser')
     page_title = soup.find('title').text
     if 'Access Denied' in page_title:
-        return ('', {})
+        return '', {}
     attributes = {}
     details_list = soup.find('div', class_='event-detail')
     release_year = get_specific_film_attribute(details_list, 'release_year')
     attributes['language'] = get_specific_film_attribute(details_list, 'languages')
     attributes['format'] = get_specific_film_attribute(details_list, 'format')
     film_page_details_cache[film_url] = (release_year, attributes)
-    return (release_year, attributes)
+    return release_year, attributes
 
 
 def get_specific_film_attribute(details_list: BeautifulSoup, attribute_name: str) -> str:
     attribute_soup = details_list.find('li', class_=attribute_name)
-    if attribute_soup == None:
-        return ""
+    if attribute_soup is None:
+        return ''
     attribute_value = attribute_soup.find('p').text.strip().lower()
     return attribute_value
 

--- a/src/showingpreviously/cinemas/centre_for_the_moving_image.py
+++ b/src/showingpreviously/cinemas/centre_for_the_moving_image.py
@@ -120,7 +120,9 @@ def get_film_page_details(cinema: dict[str, any], film_url: str) -> (str, dict[s
         details_list = soup.find('div', class_='event-detail')
         release_year = get_specific_film_attribute(details_list, 'release_year')
         attributes['language'] = get_specific_film_attribute(details_list, 'languages')
-        attributes['format'] = get_specific_film_attribute(details_list, 'format')
+        filmFormat =  get_specific_film_attribute(details_list, 'format')
+        if filmFormat != '':
+            attributes['format'] = [filmFormat]
     film_page_details_cache[film_url] = (release_year, attributes)
     return release_year, attributes
 

--- a/src/showingpreviously/cinemas/centre_for_the_moving_image.py
+++ b/src/showingpreviously/cinemas/centre_for_the_moving_image.py
@@ -44,7 +44,7 @@ def get_days_to_fetch() -> [datetime.datetime]:
     return date_list
 
 
-def get_showings_for_date(cinema: dict[str, any], fetch_date: datetime.datetime) -> [Showing]:
+def get_showings_for_date(cinema: dict[str, any], fetch_date: datetime.date) -> [Showing]:
     showings = []
     fetch_date_str = fetch_date.strftime('%Y-%m-%d')
     whats_on_url = f'{cinema["base_url"]}/whats-on/{fetch_date_str}'
@@ -86,10 +86,10 @@ def get_showing_type_attributes(film_name: str, showing_date_str: str, showing: 
     for showing_type in showing_type_list:
         showing_type_attribute = [attr for attr in showing_type['class'] if attr != 'showing-type']
         if len(showing_type_attribute) != 1:
-            raise CinemaArchiverException('Expected one showing type attribute for {film_name} on {showing_date_str}: {str(showing_type_attribute)}')
+            raise CinemaArchiverException(f'Expected one showing type attribute for {film_name} on {showing_date_str}: {str(showing_type_attribute)}')
         showing_type_attribute = showing_type_attribute[0]
         if showing_type_attribute not in KNOWN_SHOWING_TYPE_ATTRIBUTES:
-            raise CinemaArchiverException('Unknown showing type attribute for {film_name} on {showing_date_str}: {showing_type_attribute}')
+            raise CinemaArchiverException(f'Unknown showing type attribute for {film_name} on {showing_date_str}: {showing_type_attribute}')
         attributes[showing_type_attribute] = True
     return attributes
 

--- a/src/showingpreviously/cli.py
+++ b/src/showingpreviously/cli.py
@@ -1,6 +1,8 @@
+from typing import Optional
+
 import click
 
-from showingpreviously.archiver import run_all, all_cinema_chains
+from showingpreviously.archiver import run_all, run_single, all_cinema_chains
 from showingpreviously.db import db_info, database_location
 
 
@@ -19,9 +21,13 @@ def info_cmd() -> None:
 
 
 @cli.command('run')
-def run_cmd() -> None:
+@click.option('--chain', default=None, show_default=True, type=click.STRING, help='The archiver class name to run')
+def run_cmd(chain: Optional[str]) -> None:
     """Runs the archiver on all cinema chains"""
-    run_all()
+    if chain is None:
+        run_all()
+    else:
+        run_single(chain)
 
 
 if __name__ == '__main__':

--- a/src/showingpreviously/cli.py
+++ b/src/showingpreviously/cli.py
@@ -17,7 +17,7 @@ def info_cmd() -> None:
     print('ShowingPreviously: A cinema showtimes archiver')
     print('The database is stored at "%s".' % database_location)
     print('There are %s cinema chains installed' % len(all_cinema_chains))
-    print('In the database we have %s chains, with %s cinemas and %s screens, and %s films.' % db_info())
+    print('In the database we have %s chains, with %s cinemas and %s screens, %s films and %s showings.' % db_info())
 
 
 @cli.command('run')

--- a/src/showingpreviously/db.py
+++ b/src/showingpreviously/db.py
@@ -58,7 +58,8 @@ def db_info() -> (int, int, int, int):
         cinema_count = cur.execute('SELECT COUNT(*) FROM cinemas').fetchone()[0]
         screen_count = cur.execute('SELECT COUNT(*) FROM screens').fetchone()[0]
         film_count = cur.execute('SELECT COUNT(*) FROM films').fetchone()[0]
-    return chains_count, cinema_count, screen_count, film_count
+        showing_count = cur.execute('SELECT COUNT(*) FROM showings').fetchone()[0]
+    return chains_count, cinema_count, screen_count, film_count, showing_count
 
 
 database_location = os.path.join(data_dir, DATABASE_NAME)

--- a/src/showingpreviously/db.py
+++ b/src/showingpreviously/db.py
@@ -37,7 +37,7 @@ def add_showing(film_name: str, film_year: str, chain_name: str, cinema_name: st
     json_attributes_string = json.dumps(json_attributes)
     with closing(conn.cursor()) as cur:
         cur.execute(
-            'INSERT OR IGNORE INTO showings (filmName, filmYear, chainName, cinemaName, screenName, utc_time, jsonAttributes) values (?, ?, ?, ?, ?, ?, ?)',
+            'INSERT OR REPLACE INTO showings (filmName, filmYear, chainName, cinemaName, screenName, utc_time, jsonAttributes) values (?, ?, ?, ?, ?, ?, ?)',
             (film_name, film_year, chain_name, cinema_name, screen_name, epoch_time, json_attributes_string,)
         )
     conn.commit()

--- a/src/showingpreviously/db.py
+++ b/src/showingpreviously/db.py
@@ -16,7 +16,7 @@ def add_chain(chain_name: str) -> None:
 def add_cinema(chain_name: str, cinema_name: str, cinema_timezone: str) -> None:
     epoch_started_archiving = int(datetime.now().timestamp())
     with closing(conn.cursor()) as cur:
-        cur.execute('INSERT OR IGNORE INTO cinemas (chainName, name, timezone, utc_started_archiving) values (?, ?, ?, ?)', (chain_name, cinema_name, cinema_timezone, epoch_started_archiving,))
+        cur.execute('INSERT OR IGNORE INTO cinemas (chainName, name, timezone, utcStartedArchiving) values (?, ?, ?, ?)', (chain_name, cinema_name, cinema_timezone, epoch_started_archiving,))
     conn.commit()
 
 
@@ -37,7 +37,7 @@ def add_showing(film_name: str, film_year: str, chain_name: str, cinema_name: st
     json_attributes_string = json.dumps(json_attributes)
     with closing(conn.cursor()) as cur:
         cur.execute(
-            'INSERT OR REPLACE INTO showings (filmName, filmYear, chainName, cinemaName, screenName, utc_time, jsonAttributes) values (?, ?, ?, ?, ?, ?, ?)',
+            'INSERT OR REPLACE INTO showings (filmName, filmYear, chainName, cinemaName, screenName, utcTime, jsonAttributes) values (?, ?, ?, ?, ?, ?, ?)',
             (film_name, film_year, chain_name, cinema_name, screen_name, epoch_time, json_attributes_string,)
         )
     conn.commit()
@@ -46,10 +46,10 @@ def add_showing(film_name: str, film_year: str, chain_name: str, cinema_name: st
 def create_table() -> None:
     with closing(conn.cursor()) as cur:
         cur.execute('CREATE TABLE IF NOT EXISTS chains (name TEXT, PRIMARY KEY (name))')
-        cur.execute('CREATE TABLE IF NOT EXISTS cinemas (chainName TEXT, name TEXT, timezone TEXT, utc_started_archiving INT, PRIMARY KEY (chainName, name), FOREIGN KEY (chainName) REFERENCES chains(name))')
+        cur.execute('CREATE TABLE IF NOT EXISTS cinemas (chainName TEXT, name TEXT, timezone TEXT, utcStartedArchiving INT, PRIMARY KEY (chainName, name), FOREIGN KEY (chainName) REFERENCES chains(name))')
         cur.execute('CREATE TABLE IF NOT EXISTS screens (chainName TEXT, cinemaName TEXT, name TEXT, PRIMARY KEY (chainName, cinemaName, name), FOREIGN KEY (chainName) REFERENCES cinemas (chainName), FOREIGN KEY (cinemaName) REFERENCES cinemas (name))')
         cur.execute('CREATE TABLE IF NOT EXISTS films (name TEXT, year TEXT, PRIMARY KEY (name, year))')
-        cur.execute('CREATE TABLE IF NOT EXISTS showings (filmName TEXT, filmYear TEXT, chainName TEXT, cinemaName TEXT, screenName TEXT, utc_time INT, jsonAttributes TEXT, PRIMARY KEY (filmName, filmYear, chainName, cinemaName, screenName, utc_time), FOREIGN KEY (filmName) REFERENCES films (name), FOREIGN KEY (filmYear) REFERENCES films (year), FOREIGN KEY (chainName) REFERENCES screens (chainName), FOREIGN KEY (cinemaName) REFERENCES screens (cinemaName), FOREIGN KEY (screenName) REFERENCES screens (name))')
+        cur.execute('CREATE TABLE IF NOT EXISTS showings (filmName TEXT, filmYear TEXT, chainName TEXT, cinemaName TEXT, screenName TEXT, utcTime INT, jsonAttributes TEXT, PRIMARY KEY (filmName, filmYear, chainName, cinemaName, screenName, utcTime), FOREIGN KEY (filmName) REFERENCES films (name), FOREIGN KEY (filmYear) REFERENCES films (year), FOREIGN KEY (chainName) REFERENCES screens (chainName), FOREIGN KEY (cinemaName) REFERENCES screens (cinemaName), FOREIGN KEY (screenName) REFERENCES screens (name))')
 
 
 def db_info() -> (int, int, int, int):

--- a/src/showingpreviously/model.py
+++ b/src/showingpreviously/model.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 class Chain:
     def __init__(self, name: str) -> None:
-        self.name = name
+        self.name = name.strip()
 
     def __repr__(self) -> str:
         return f'Chain "{self.name}"'
@@ -11,7 +11,7 @@ class Chain:
 
 class Cinema:
     def __init__(self, name: str, timezone: str) -> None:
-        self.name = name
+        self.name = name.strip()
         self.timezone = timezone
 
     def __repr__(self) -> str:
@@ -20,7 +20,7 @@ class Cinema:
 
 class Screen:
     def __init__(self, name: str) -> None:
-        self.name = name
+        self.name = name.strip()
 
     def __repr__(self) -> str:
         return f'Screen "{self.name}"'
@@ -28,8 +28,8 @@ class Screen:
 
 class Film:
     def __init__(self, name: str, year: str) -> None:
-        self.name = name
-        self.year = year
+        self.name = name.strip()
+        self.year = str(year).strip()
 
     def __repr__(self) -> str:
         return f'Film "{self.name}" ({self.year})'


### PR DESCRIPTION
Added the cinemas operated by the [Centre for the Moving Image](https://www.cmi-scotland.co.uk/) to the archiver:
1. [Filmhouse Edinburgh](https://www.filmhousecinema.com/)
2. [Belmont Filmhouse](https://www.belmontfilmhouse.com/)