### PR TITLE
Model: ensure film names are in all uppercase

### DIFF
--- a/src/showingpreviously/model.py
+++ b/src/showingpreviously/model.py
@@ -28,7 +28,7 @@ class Screen:
 
 class Film:
     def __init__(self, name: str, year: str) -> None:
-        self.name = name.strip()
+        self.name = name.strip().upper()
         self.year = str(year).strip()
 
     def __repr__(self) -> str:


### PR DESCRIPTION
It is necessary to ensure that film names are stored in the database as uppercase, because the database is case-sensitive and different cinemas have different rules for the capitalisation of film names (e.g: the Prince Charles Cinema - in the process of being added to the archiver - has each title in full uppercase).