### PR TITLE
Cli: Add option to 'info' to view all the installed chains

### DIFF
--- a/src/showingpreviously/cli.py
+++ b/src/showingpreviously/cli.py
@@ -12,12 +12,16 @@ def cli() -> None:
 
 
 @cli.command('info')
-def info_cmd() -> None:
+@click.option('--list-chains', 'list_chains', is_flag=True, default=False, show_default=False, type=click.BOOL, help='List all the chains that can be run with the --chain option')
+def info_cmd(list_chains: bool) -> None:
     """Prints basic information about showingpreviously, and the database contents"""
     print('ShowingPreviously: A cinema showtimes archiver')
-    print('The database is stored at "%s".' % database_location)
-    print('There are %s cinema chains installed' % len(all_cinema_chains))
-    print('In the database we have %s chains, with %s cinemas and %s screens, %s films and %s showings.' % db_info())
+    print(f'The database is stored at "{database_location}".')
+    print(f'There are {len(all_cinema_chains)} cinema chains installed')
+    chains_count, cinema_count, screen_count, film_count, showing_count = db_info()
+    print(f'In the database we have {chains_count} chains, with {cinema_count} cinemas and {screen_count} screens, {film_count} films and {showing_count} showings.')
+    installed_chains = ', '.join([type(cinema_chain).__name__ for cinema_chain in all_cinema_chains])
+    print(f'The installed chains are: {installed_chains}')
 
 
 @cli.command('run')
@@ -27,6 +31,9 @@ def run_cmd(chain: Optional[str]) -> None:
     if chain is None:
         run_all()
     else:
+        installed_chains = [type(cinema_chain).__name__ for cinema_chain in all_cinema_chains]
+        if chain not in installed_chains:
+            raise click.BadOptionUsage('--chain', f'No such installed chain "{chain}"')
         run_single(chain)
 
 


### PR DESCRIPTION
The `info` command has a new option `--list-chains` that prints a comma-separated list of the installed chains at the end of the info message.

This is useful because without this, there is no way (other than inspecting the source code) to get the values required by the `--chain` argument of the `run` command.

I'm not super happy with the comma-separated list, though. My preference would be a list where you get the class name, followed by a brief description of the chain (a bit like how arguments are presented with the argument name and a brief description of the argument). This will require a change to the model (since we don't have a description for each chain), however I think it is worth it.

Thoughts?