### PR TITLE
Add cinema: The Light Cinemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Installing this module will install the `showingpreviously` command. This has tw
 - [Cineworld UK](https://www.cineworld.co.uk/) (added 2021-10-31) 
 - [Dundee Contemporary Arts Cinema](https://www.dca.org.uk/whats-on/films) (added 2021-10-29)
 - [Empire Cinemas](https://www.empirecinemas.co.uk/) (added 2021-11-07)
+- [Parkway Cinemas](https://parkwaycinemas.co.uk) (added 2021-11-14)
 - [Picturehouse](https://www.picturehouses.com/) (added 2021-11-06)
 - [The Light Cinemas](https://lightcinemas.co.uk/) (added 2021-10-07)
 - [Vue UK](https://www.myvue.com/) (added 2021-10-31)

--- a/README.md
+++ b/README.md
@@ -16,5 +16,6 @@ Installing this module will install the `showingpreviously` command. This has tw
 - [Dundee Contemporary Arts Cinema](https://www.dca.org.uk/whats-on/films) (added 2021-10-29)
 - [Empire Cinemas](https://www.empirecinemas.co.uk/) (added 2021-11-07)
 - [Picturehouse](https://www.picturehouses.com/) (added 2021-11-06)
+- [The Light Cinemas](https://lightcinemas.co.uk/) (added 2021-10-07)
 - [Vue UK](https://www.myvue.com/) (added 2021-10-31)
 - [Odeon](https://odeon.co.uk/) (added 2021-10-31)

--- a/src/showingpreviously/archiver.py
+++ b/src/showingpreviously/archiver.py
@@ -11,7 +11,8 @@ from showingpreviously.cinemas.dundee_contemporary_arts import DundeeContemporar
 from showingpreviously.cinemas.empire import Empire
 from showingpreviously.cinemas.vista_system import Odeon, Curzon
 from showingpreviously.cinemas.picturehouse import Picturehouse
-from showingpreviously.cinemas.thelight import TheLight
+from showingpreviously.cinemas.lpvs import TheLight
+from showingpreviously.cinemas.parkway import Parkway
 from showingpreviously.cinemas.vue import Vue
 
 all_cinema_chains = [
@@ -21,6 +22,7 @@ all_cinema_chains = [
     DundeeContemporaryArts(),
     Empire(),
     Odeon(),
+    Parkway(),
     Picturehouse(),
     TheLight(),
     Vue(),

--- a/src/showingpreviously/archiver.py
+++ b/src/showingpreviously/archiver.py
@@ -11,6 +11,7 @@ from showingpreviously.cinemas.dundee_contemporary_arts import DundeeContemporar
 from showingpreviously.cinemas.empire import Empire
 from showingpreviously.cinemas.vista_system import Odeon, Curzon
 from showingpreviously.cinemas.picturehouse import Picturehouse
+from showingpreviously.cinemas.thelight import TheLight
 from showingpreviously.cinemas.vue import Vue
 
 all_cinema_chains = [
@@ -21,6 +22,7 @@ all_cinema_chains = [
     Empire(),
     Odeon(),
     Picturehouse(),
+    TheLight(),
     Vue(),
 ]
 

--- a/src/showingpreviously/cinemas/lpvs.py
+++ b/src/showingpreviously/cinemas/lpvs.py
@@ -2,21 +2,19 @@ import re
 import json
 from datetime import datetime
 from typing import Optional
+from bs4 import BeautifulSoup
 
 import showingpreviously.requests as requests
 from showingpreviously.model import ChainArchiver, CinemaArchiverException, Chain, Cinema, Screen, Film, Showing
 from showingpreviously.consts import STANDARD_DAYS_AHEAD, UK_TIMEZONE, UNKNOWN_FILM_YEAR
 
 
-CINEMAS_URL = 'https://walsall.thelight.co.uk'
 SHOWINGS_URL = '{cinema_url}/resource/services/miniguide/data.ashx'
 SCREEN_API_URL = '{cinema_url}/api/book/cinema/session'
 
 TOKEN_PATTERN = re.compile(r'\'Token\':\s*\'(?P<token>.+?)\'')
-CINEMAS_JSON_PATTERN = re.compile(r'var\s+__sites\s*=\s*(?P<cinemas_json>.+?)\s*;')
-SHOWINGS_JSON_PATTERN = re.compile(r'var\s+__gfminiguidedata\s*=\s*(?P<showings_json>.+?)\s*;')
-SCREEN_LIGHTCINEMAS_PATTERN = re.compile(r'cinema-screen-name">.+?-\s*(?P<screen_name>.+?)<')
-CHAIN = Chain('The Light Cinemas')
+SHOWINGS_JSON_PATTERN = re.compile(r'var\s+__gfminiguidedata\s*=\s*(?P<showings_json>.+?})\s*;')
+SCREEN_PATTERN = re.compile(r'cinema-screen-name">.+?-\s*(?P<screen_name>.+?)<')
 
 
 def get_response(url: str) -> requests.Response:
@@ -36,21 +34,6 @@ def get_lpvs(cinema_url: str) -> str:
     r = requests.get(cinema_url)
     lpvs = r.cookies.get('lpvs')
     return lpvs
-
-
-def get_cinemas_as_dict() -> dict[str, Cinema]:
-    r = get_response(CINEMAS_URL)
-    cinemas_json = CINEMAS_JSON_PATTERN.search(r.text).group('cinemas_json')
-    try:
-        cinemas_data = json.loads(cinemas_json)
-    except json.JSONDecodeError:
-        raise CinemaArchiverException(f'Error decoding JSON data from string: {cinemas_json}')
-    cinemas = {}
-    for cinema in cinemas_data:
-        cinema_name = cinema['title']
-        cinema_url = cinema['url']
-        cinemas[cinema_url] = Cinema(cinema_name, UK_TIMEZONE)
-    return cinemas
 
 
 def get_attributes(collections: [dict[str, any]]) -> dict[str, any]:
@@ -81,11 +64,11 @@ def get_screen_thelight(cinema_url: str, showing_id: str, token: str) -> Screen:
 
 def get_screen_lightcinemas(booking_url: str, lpvs: str):
     r = requests.get(booking_url, cookies={'lpvs': lpvs})
-    screen_name = SCREEN_LIGHTCINEMAS_PATTERN.search(r.text).group('screen_name')
+    screen_name = SCREEN_PATTERN.search(r.text).group('screen_name')
     return Screen(screen_name)
 
 
-def process_showing(showing, date: str, cinema_url: str, cinema: Cinema, film: Film, token: str, lpvs: str) -> Optional[Showing]:
+def process_showing(chain: Chain, showing, date: str, cinema_url: str, cinema: Cinema, film: Film, token: str, lpvs: str) -> Optional[Showing]:
     if 'BOID' not in showing:
         # this means the screening has already started, or can't be booked, so we skip it
         return None
@@ -97,10 +80,10 @@ def process_showing(showing, date: str, cinema_url: str, cinema: Cinema, film: F
         screen = get_screen_lightcinemas(showing['Url'], lpvs)
     else:
         screen = get_screen_thelight(cinema_url, showing_id, token)
-    return Showing(film, date_and_time, CHAIN, cinema, screen, json_attributes)
+    return Showing(film, date_and_time, chain, cinema, screen, json_attributes)
 
 
-def get_showings(cinema_url: str, cinema: Cinema) -> [Showing]:
+def get_showings(chain: Chain, cinema_url: str, cinema: Cinema) -> [Showing]:
     token = lpvs = None
     if 'thelight' in cinema_url:
         token = get_token(cinema_url)
@@ -124,21 +107,50 @@ def get_showings(cinema_url: str, cinema: Cinema) -> [Showing]:
             if 'Sessions' not in day:
                 for format in day['Formats']:
                     for showing in format['Sessions']:
-                        res = process_showing(showing, date, cinema_url, cinema, film, token, lpvs)
+                        res = process_showing(chain, showing, date, cinema_url, cinema, film, token, lpvs)
                         if res is not None:
                             showings.append(res)
             else:
                 for showing in day['Sessions']:
-                    res = process_showing(showing, date, cinema_url, cinema, film, token, lpvs)
+                    res = process_showing(chain, showing, date, cinema_url, cinema, film, token, lpvs)
                     if res is not None:
                         showings.append(res)
     return showings
 
 
-class TheLight(ChainArchiver):
+class LPVS(ChainArchiver):
+    def __init__(self, chain: Chain):
+        self.chain = chain
+
+    def get_cinemas_as_dict(self) -> dict[str, Cinema]:
+        pass
+
     def get_showings(self) -> [Showing]:
         showings = []
-        cinemas = get_cinemas_as_dict()
+        cinemas = self.get_cinemas_as_dict()
         for cinema_url, cinema in cinemas.items():
-            showings += get_showings(cinema_url, cinema)
+            showings += get_showings(self.chain, cinema_url, cinema)
         return showings
+
+
+class TheLight(LPVS):
+    CHAIN = Chain('The Light Cinemas')
+    CINEMAS_URL = 'https://walsall.thelight.co.uk'
+    CINEMAS_JSON_PATTERN = re.compile(r'var\s+__sites\s*=\s*(?P<cinemas_json>.+?)\s*;')
+
+    def __init__(self):
+        super().__init__(TheLight.CHAIN)
+
+    def get_cinemas_as_dict(self) -> dict[str, Cinema]:
+        r = get_response(TheLight.CINEMAS_URL)
+        cinemas_json = TheLight.CINEMAS_JSON_PATTERN.search(r.text).group('cinemas_json')
+        try:
+            cinemas_data = json.loads(cinemas_json)
+        except json.JSONDecodeError:
+            raise CinemaArchiverException(f'Error decoding JSON data from string: {cinemas_json}')
+        cinemas = {}
+        for cinema in cinemas_data:
+            cinema_name = cinema['title']
+            cinema_url = cinema['url']
+            cinemas[cinema_url] = Cinema(cinema_name, UK_TIMEZONE)
+        return cinemas

--- a/src/showingpreviously/cinemas/parkway.py
+++ b/src/showingpreviously/cinemas/parkway.py
@@ -1,0 +1,104 @@
+import time
+import re
+from datetime import datetime
+from bs4 import BeautifulSoup
+
+import showingpreviously.requests as requests
+from showingpreviously.model import ChainArchiver, CinemaArchiverException, Chain, Cinema, Screen, Film, Showing
+from showingpreviously.consts import UK_TIMEZONE
+from showingpreviously.cinemas.lpvs import get_showings as lpvs_get_showings
+
+
+SHOWING_LIST_URL = '{cinema_url}/?when={date_code}&type=all'
+SCREEN_NAME_PATTERN = re.compile(r'Showing In&nbsp;(?P<screen_name>.+?) -')
+SCREENING_FINISHED_TEXT = 'The performance has expired, or been taken off sale'
+SCREENING_NO_EVENTS_TEXT = 'No event exists for the specified event code.'
+
+
+def get_response(url: str) -> requests.Response:
+    r = requests.get(url)
+    if r.status_code != 200:
+        raise CinemaArchiverException(f'Got status code {r.status_code} when fetching URL {url}')
+    return r
+
+
+def get_cinemas_as_dict() -> dict[str, Cinema]:
+    form_data = {}
+    r = get_response(Parkway.CINEMAS_URL)
+    soup = BeautifulSoup(r.text, features='html.parser')
+    form_data['__VIEWSTATE'] = soup.find('input', {'name': '__VIEWSTATE'})['value']
+    form_data['__VIEWSTATEGENERATOR'] = soup.find('input', {'name': '__VIEWSTATEGENERATOR'})['value']
+    cinemas_list = soup.find('ul', {'class': 'cinemas'})
+    cinemas = {}
+    for cinema_item in cinemas_list.find_all('li'):
+        cinema_name = next(cinema_item.find('strong').children)
+        form_data['go'] = cinema_item.find('button', {'value': True})['value']
+        r = requests.post(Parkway.CINEMAS_URL, data=form_data)
+        cinema_url = r.url
+        cinemas[cinema_url] = Cinema(cinema_name, UK_TIMEZONE)
+    return cinemas
+
+
+def get_date_and_screen(booking_url: str, delay_time: int) -> (datetime, Screen):
+    try:
+        r = get_response(booking_url)
+    except requests.exceptions.ConnectionError:
+        # admit-one.eu has annoying rate limiting. try again, with an increased back-off
+        delay_time += 10
+        time.sleep(delay_time)
+        return get_date_and_screen(booking_url, delay_time)
+    if SCREENING_FINISHED_TEXT in r.text or SCREENING_NO_EVENTS_TEXT in r.text:
+        # the screening has ended, and we can't get the screen name. return nothing
+        return None, None
+    soup = BeautifulSoup(r.text, features='html.parser')
+    date_str = next(soup.find('div', {'class': 'OLCT_ticketInfoText'}).children).text.strip()
+    date = datetime.strptime(date_str, '%A %d %B %Y @ %H:%M')
+    screen_name = SCREEN_NAME_PATTERN.search(r.text).group('screen_name')
+    return date, Screen(screen_name)
+
+
+def get_film(film_url: str, title: str) -> Film:
+    r = get_response(film_url)
+    soup = BeautifulSoup(r.text, features='html.parser')
+    release_date = soup.find('b', text='Release Date:').next_sibling.text.strip()
+    release_year = release_date[-4:]
+    return Film(title, release_year)
+
+
+def get_showings(cinema_url: str, cinema: Cinema) -> [Showing]:
+    showings = []
+    for date_code in ['today', 'tomorrow', 'plus2']:
+        url = SHOWING_LIST_URL.format(cinema_url=cinema_url, date_code=date_code)
+        r = get_response(url)
+        soup = BeautifulSoup(r.text, features='html.parser')
+        for film_card in soup.find_all('div', {'class': 'OLCT_performance'}):
+            film_h3 = film_card.find('h3')
+            film_title = film_h3.text
+            film_link = film_h3.find_parent('a', {'href': True})['href']
+            film = get_film(film_link, film_title)
+
+            for booking_link in film_card.find_all('a', href=lambda href: href and 'admit-one.eu/?p=tickets' in href):
+                link = booking_link['href']
+                date, screen = get_date_and_screen(link, 0)
+                if date is None or screen is None:
+                    # the screening has expired, we can't do anything with it
+                    continue
+                showings.append(Showing(film, date, Parkway.CHAIN, cinema, screen, {}))
+    return showings
+
+
+class Parkway(ChainArchiver):
+    CHAIN = Chain('Parkway Cinemas')
+    CINEMAS_URL = 'https://www.parkwaycinemas.co.uk/'
+
+    # this method either uses the lpvs code, or the admit-one code
+    def get_showings(self) -> [Showing]:
+        showings = []
+        cinemas = get_cinemas_as_dict()
+        for cinema_url, cinema in cinemas.items():
+            if 'barnsley' in cinema_url:
+                # special logic for Barnsley which uses its own website system
+                showings += get_showings(cinema_url, cinema)
+            else:
+                showings += lpvs_get_showings(Parkway.CHAIN, cinema_url, cinema)
+        return showings

--- a/src/showingpreviously/cinemas/thelight.py
+++ b/src/showingpreviously/cinemas/thelight.py
@@ -5,13 +5,13 @@ from typing import Optional
 
 import showingpreviously.requests as requests
 from showingpreviously.model import ChainArchiver, CinemaArchiverException, Chain, Cinema, Screen, Film, Showing
+from showingpreviously.consts import STANDARD_DAYS_AHEAD, UK_TIMEZONE, UNKNOWN_FILM_YEAR
 
 
 CINEMAS_URL = 'https://walsall.thelight.co.uk'
 SHOWINGS_URL = '{cinema_url}/resource/services/miniguide/data.ashx'
 SCREEN_API_URL = '{cinema_url}/api/book/cinema/session'
 
-DAYS_AHEAD = 2
 TOKEN_PATTERN = re.compile(r'\'Token\':\s*\'(?P<token>.+?)\'')
 CINEMAS_JSON_PATTERN = re.compile(r'var\s+__sites\s*=\s*(?P<cinemas_json>.+?)\s*;')
 SHOWINGS_JSON_PATTERN = re.compile(r'var\s+__gfminiguidedata\s*=\s*(?P<showings_json>.+?)\s*;')
@@ -49,7 +49,7 @@ def get_cinemas_as_dict() -> dict[str, Cinema]:
     for cinema in cinemas_data:
         cinema_name = cinema['title']
         cinema_url = cinema['url']
-        cinemas[cinema_url] = Cinema(cinema_name, 'Europe/London')
+        cinemas[cinema_url] = Cinema(cinema_name, UK_TIMEZONE)
     return cinemas
 
 
@@ -116,9 +116,9 @@ def get_showings(cinema_url: str, cinema: Cinema) -> [Showing]:
     showings = []
     for film_data in showings_data['Schedule']:
         film_name = film_data['Title']
-        film_year = '0'  # todo: somehow get the year
+        film_year = UNKNOWN_FILM_YEAR
         film = Film(film_name, film_year)
-        for i in range(0, min(DAYS_AHEAD, len(film_data['Dates']))):
+        for i in range(0, min(STANDARD_DAYS_AHEAD, len(film_data['Dates']))):
             day = film_data['Dates'][i]
             date = day['Key']
             if 'Sessions' not in day:

--- a/src/showingpreviously/cinemas/thelight.py
+++ b/src/showingpreviously/cinemas/thelight.py
@@ -1,0 +1,144 @@
+import re
+import json
+from datetime import datetime
+from typing import Optional
+
+import showingpreviously.requests as requests
+from showingpreviously.model import ChainArchiver, CinemaArchiverException, Chain, Cinema, Screen, Film, Showing
+
+
+CINEMAS_URL = 'https://walsall.thelight.co.uk'
+SHOWINGS_URL = '{cinema_url}/resource/services/miniguide/data.ashx'
+SCREEN_API_URL = '{cinema_url}/api/book/cinema/session'
+
+DAYS_AHEAD = 2
+TOKEN_PATTERN = re.compile(r'\'Token\':\s*\'(?P<token>.+?)\'')
+CINEMAS_JSON_PATTERN = re.compile(r'var\s+__sites\s*=\s*(?P<cinemas_json>.+?)\s*;')
+SHOWINGS_JSON_PATTERN = re.compile(r'var\s+__gfminiguidedata\s*=\s*(?P<showings_json>.+?)\s*;')
+SCREEN_LIGHTCINEMAS_PATTERN = re.compile(r'cinema-screen-name">.+?-\s*(?P<screen_name>.+?)<')
+CHAIN = Chain('The Light Cinemas')
+
+
+def get_response(url: str) -> requests.Response:
+    r = requests.get(url)
+    if r.status_code != 200:
+        raise CinemaArchiverException(f'Got status code {r.status_code} when fetching URL {url}')
+    return r
+
+
+def get_token(cinema_url: str) -> str:
+    r = requests.get(cinema_url)
+    token = TOKEN_PATTERN.search(r.text).group('token')
+    return token
+
+
+def get_lpvs(cinema_url: str) -> str:
+    r = requests.get(cinema_url)
+    lpvs = r.cookies.get('lpvs')
+    return lpvs
+
+
+def get_cinemas_as_dict() -> dict[str, Cinema]:
+    r = get_response(CINEMAS_URL)
+    cinemas_json = CINEMAS_JSON_PATTERN.search(r.text).group('cinemas_json')
+    try:
+        cinemas_data = json.loads(cinemas_json)
+    except json.JSONDecodeError:
+        raise CinemaArchiverException(f'Error decoding JSON data from string: {cinemas_json}')
+    cinemas = {}
+    for cinema in cinemas_data:
+        cinema_name = cinema['title']
+        cinema_url = cinema['url']
+        cinemas[cinema_url] = Cinema(cinema_name, 'Europe/London')
+    return cinemas
+
+
+def get_attributes(collections: [dict[str, any]]) -> dict[str, any]:
+    attributes = {}
+    for collection in collections:
+        if collection['Title'] == 'Audio Description':
+            attributes['audio-described'] = True
+        elif collection['Title'] == 'Subtitled for hard of hearing':
+            attributes['captioned'] = True
+        elif collection['Title'] == 'Silver Screen':
+            attributes['senior'] = True
+        elif collection['Title'] == 'Baby-friendly':
+            attributes['carers-and-babies'] = True
+    return attributes
+
+
+def get_screen_thelight(cinema_url: str, showing_id: str, token: str) -> Screen:
+    url = SCREEN_API_URL.format(cinema_url=cinema_url)
+    data = {'SessionId': showing_id, 'Token': token}
+    r = requests.post(url, data=json.dumps(data))
+    try:
+        booking_data = r.json()
+    except json.JSONDecodeError:
+        raise CinemaArchiverException(f'Error decoding JSON data from URL: {url}')
+    screen_name = booking_data['Data']['ScreenName']
+    return Screen(screen_name)
+
+
+def get_screen_lightcinemas(booking_url: str, lpvs: str):
+    r = requests.get(booking_url, cookies={'lpvs': lpvs})
+    screen_name = SCREEN_LIGHTCINEMAS_PATTERN.search(r.text).group('screen_name')
+    return Screen(screen_name)
+
+
+def process_showing(showing, date: str, cinema_url: str, cinema: Cinema, film: Film, token: str, lpvs: str) -> Optional[Showing]:
+    if 'BOID' not in showing:
+        # this means the screening has already started, or can't be booked, so we skip it
+        return None
+    showing_id = showing['BOID']
+    time = showing['Display']
+    date_and_time = datetime.strptime(f'{date} {time}', '%Y%m%d %H.%M')
+    json_attributes = get_attributes(showing['Collections'])
+    if 'Url' in showing and showing['Url'].strip() != '':
+        screen = get_screen_lightcinemas(showing['Url'], lpvs)
+    else:
+        screen = get_screen_thelight(cinema_url, showing_id, token)
+    return Showing(film, date_and_time, CHAIN, cinema, screen, json_attributes)
+
+
+def get_showings(cinema_url: str, cinema: Cinema) -> [Showing]:
+    token = lpvs = None
+    if 'thelight' in cinema_url:
+        token = get_token(cinema_url)
+    else:
+        lpvs = get_lpvs(cinema_url)
+    url = SHOWINGS_URL.format(cinema_url=cinema_url)
+    r = get_response(url)
+    showings_json = SHOWINGS_JSON_PATTERN.search(r.text).group('showings_json')
+    try:
+        showings_data = json.loads(showings_json)
+    except json.JSONDecodeError:
+        raise CinemaArchiverException(f'Error decoding JSON data from string: {showings_json}')
+    showings = []
+    for film_data in showings_data['Schedule']:
+        film_name = film_data['Title']
+        film_year = '0'  # todo: somehow get the year
+        film = Film(film_name, film_year)
+        for i in range(0, min(DAYS_AHEAD, len(film_data['Dates']))):
+            day = film_data['Dates'][i]
+            date = day['Key']
+            if 'Sessions' not in day:
+                for format in day['Formats']:
+                    for showing in format['Sessions']:
+                        res = process_showing(showing, date, cinema_url, cinema, film, token, lpvs)
+                        if res is not None:
+                            showings.append(res)
+            else:
+                for showing in day['Sessions']:
+                    res = process_showing(showing, date, cinema_url, cinema, film, token, lpvs)
+                    if res is not None:
+                        showings.append(res)
+    return showings
+
+
+class TheLight(ChainArchiver):
+    def get_showings(self) -> [Showing]:
+        showings = []
+        cinemas = get_cinemas_as_dict()
+        for cinema_url, cinema in cinemas.items():
+            showings += get_showings(cinema_url, cinema)
+        return showings


### PR DESCRIPTION
Adds [The Light Cinemas]() to the archiver.

Note: as far as I can see, The Light does not display the release year of movies _anywhere_, and therefore **this archiver does not add release years**, and simply fills them as `0`.

Also note: Light Cinemas is interesting. They have two domains, lightcinemas.co.uk and thelight.co.uk, and some of their cinemas are subdomains of the first, and others the second (never both). The API is the same for both, but the booking system is different. We use the booking system to get the screen of a showing, so there is two functions for getting the screen, one for each of the booking systems.