### PR TITLE
Add cinema: Reel Cinemas via Cinemas Online

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,5 @@ Installing this module will install the `showingpreviously` command. This has tw
 - [Centre for the Moving Image](https://www.cmi-scotland.co.uk/) ([Filmhouse Edinburgh](https://www.filmhousecinema.com/) and [Belmont Filmhouse](https://www.belmontfilmhouse.com/)) (added 2021-10-30)
 - [Reel Cinemas](https://reelcinemas.co.uk/) (added 2021-11-10)
 - [Dundee Contemporary Arts Cinema](https://www.dca.org.uk/whats-on/films) (added 2021-10-29)
+- [Northern Morris Cinemas](https://nm-cinemas.co.uk/) (added 2021-11-12)
 - [Vue UK](https://www.myvue.com/) (added 2021-10-31)

--- a/README.md
+++ b/README.md
@@ -12,5 +12,6 @@ Installing this module will install the `showingpreviously` command. This has tw
 
 ## Supported Cinemas
 - [Centre for the Moving Image](https://www.cmi-scotland.co.uk/) ([Filmhouse Edinburgh](https://www.filmhousecinema.com/) and [Belmont Filmhouse](https://www.belmontfilmhouse.com/)) (added 2021-10-30)
+- [Reel Cinemas](https://reelcinemas.co.uk/) (added 2021-11-10)
 - [Dundee Contemporary Arts Cinema](https://www.dca.org.uk/whats-on/films) (added 2021-10-29)
 - [Vue UK](https://www.myvue.com/) (added 2021-10-31)

--- a/src/showingpreviously/archiver.py
+++ b/src/showingpreviously/archiver.py
@@ -5,11 +5,13 @@ from showingpreviously.model import Showing, ChainArchiver
 
 # import cinemas here, and add them to the all_cinema_chains list
 from showingpreviously.cinemas.centre_for_the_moving_image import CentreForTheMovingImage
+from showingpreviously.cinemas.cinemasonline import ReelCinemas
 from showingpreviously.cinemas.dundee_contemporary_arts import DundeeContemporaryArts
 from showingpreviously.cinemas.vue import Vue
 
 all_cinema_chains = [
     CentreForTheMovingImage(),
+    ReelCinemas(),
     DundeeContemporaryArts(),
     Vue(),
 ]

--- a/src/showingpreviously/archiver.py
+++ b/src/showingpreviously/archiver.py
@@ -5,7 +5,7 @@ from showingpreviously.model import Showing, ChainArchiver
 
 # import cinemas here, and add them to the all_cinema_chains list
 from showingpreviously.cinemas.centre_for_the_moving_image import CentreForTheMovingImage
-from showingpreviously.cinemas.cinemasonline import ReelCinemas
+from showingpreviously.cinemas.cinemasonline import ReelCinemas, NorthernMorris
 from showingpreviously.cinemas.dundee_contemporary_arts import DundeeContemporaryArts
 from showingpreviously.cinemas.vue import Vue
 
@@ -13,6 +13,7 @@ all_cinema_chains = [
     CentreForTheMovingImage(),
     ReelCinemas(),
     DundeeContemporaryArts(),
+    NorthernMorris(),
     Vue(),
 ]
 

--- a/src/showingpreviously/cinemas/cinemasonline.py
+++ b/src/showingpreviously/cinemas/cinemasonline.py
@@ -32,30 +32,6 @@ def get_cinemas_as_dict(origin: str) -> dict[str, Cinema]:
     return cinemas
 
 
-def get_attributes(showing: dict[str, any]) -> dict[str, any]:
-    attributes = {'format':[]}
-    for tag in showing['tags']:
-        if tag['is_imax']:
-            attributes['format'].append('IMAX')
-
-        if tag['name'] == 'AD':
-            attributes['audio-described'] = True
-        elif tag['name'] == 'ST':
-            attributes['subtitled'] = True
-        elif tag['name'] == 'Event':
-            attributes['event'] = True
-        elif tag['name'] in ['Live', '4K', '70mm', 'Atmos', 'HFR 30', 'IMAX', 'IMAX3D']:
-            attributes['format'].append(tag['name'])
-        elif tag['name'] == 'Seniors':
-            attributes['senior'] = True
-        elif tag['name'] == 'Baby':
-            attributes['carers-and-babies'] = True
-
-    if len(attributes['format']) == 0:
-        del attributes['format']
-    return attributes
-
-
 def get_showings(cinema_id: str, cinema: Cinema, origin: str, chain: Chain) -> [Showing]:
     url = SHOWINGS_API_URL.format(cinema_id=cinema_id)
     r = get_response(url, origin)

--- a/src/showingpreviously/cinemas/cinemasonline.py
+++ b/src/showingpreviously/cinemas/cinemasonline.py
@@ -1,0 +1,96 @@
+import json
+from datetime import datetime
+
+import showingpreviously.requests as requests
+from showingpreviously.model import ChainArchiver, CinemaArchiverException, Chain, Cinema, Screen, Film, Showing
+from showingpreviously.consts import UK_TIMEZONE
+
+
+CINEMAS_API_URL = 'http://data.cinemas-online.co.uk/cinema/venues'
+SHOWINGS_API_URL = 'https://data.cinemas-online.co.uk/cinema/shows?format=now&Venue={cinema_id}'
+
+
+def get_response(url: str, origin: str) -> requests.Response:
+    r = requests.get(url, headers={'origin': origin})
+    if r.status_code != 200:
+        raise CinemaArchiverException(f'Got status code {r.status_code} when fetching URL {url}')
+    return r
+
+
+def get_cinemas_as_dict(origin: str) -> dict[str, Cinema]:
+    r = get_response(CINEMAS_API_URL, origin)
+    try:
+        cinemas_data = r.json()
+    except json.JSONDecodeError:
+        raise CinemaArchiverException(f'Error decoding JSON data from URL {CINEMAS_API_URL}')
+    cinemas = {}
+    for cinema in cinemas_data:
+        cinema_name = cinema['Name']
+        cinema_id = cinema['PermaLink']
+        cinemas[cinema_id] = Cinema(cinema_name, UK_TIMEZONE)
+    return cinemas
+
+
+def get_attributes(showing: dict[str, any]) -> dict[str, any]:
+    attributes = {'format':[]}
+    for tag in showing['tags']:
+        if tag['is_imax']:
+            attributes['format'].append('IMAX')
+
+        if tag['name'] == 'AD':
+            attributes['audio-described'] = True
+        elif tag['name'] == 'ST':
+            attributes['subtitled'] = True
+        elif tag['name'] == 'Event':
+            attributes['event'] = True
+        elif tag['name'] in ['Live', '4K', '70mm', 'Atmos', 'HFR 30', 'IMAX', 'IMAX3D']:
+            attributes['format'].append(tag['name'])
+        elif tag['name'] == 'Seniors':
+            attributes['senior'] = True
+        elif tag['name'] == 'Baby':
+            attributes['carers-and-babies'] = True
+
+    if len(attributes['format']) == 0:
+        del attributes['format']
+    return attributes
+
+
+def get_showings(cinema_id: str, cinema: Cinema, origin: str, chain: Chain) -> [Showing]:
+    url = SHOWINGS_API_URL.format(cinema_id=cinema_id)
+    r = get_response(url, origin)
+    try:
+        showings_data = r.json()
+    except json.JSONDecodeError:
+        raise CinemaArchiverException(f'Error decoding JSON data from URL {SHOWINGS_API_URL}')
+
+    showings = []
+    for film_data in showings_data:
+        film_name = film_data['Movie']['Title']
+        release_date = film_data['Movie']['ReleaseDate'].replace('Z', '')
+        film_year = str(datetime.fromisoformat(release_date).year)
+        film = Film(film_name, film_year)
+        for showing_date in film_data['ShowDates']:
+            for showing in showing_date['Times']:
+                date = datetime.fromisoformat(showing['Time'].replace('Z', ''))
+                screen = Screen(showing['Screen'])
+                json_attributes = {}
+                showings.append(Showing(film, date, chain, cinema, screen, json_attributes))
+    return showings
+
+
+class CinemasOnline(ChainArchiver):
+    def __init__(self, chain: Chain, origin: str):
+        self.chain = chain
+        self.origin = origin
+
+    def get_showings(self) -> [Showing]:
+        showings = []
+        cinemas = get_cinemas_as_dict(self.origin)
+        for cinema_id, cinema in cinemas.items():
+            showings += get_showings(cinema_id, cinema, self.origin, self.chain)
+        return showings
+
+
+class ReelCinemas(CinemasOnline):
+    def __init__(self):
+        super().__init__(Chain('Reel Cinemas'), 'https://reelcinemas.co.uk')


### PR DESCRIPTION
Adds [Reel Cinemas](https://reelcinemas.co.uk/) to the archiver.

Note that the only attribute Reel Cinemas exposes is whether the showing is in the "Reel Lounge" or not - and this is already captured in the screen name, so the json attributes are left empty.

Reel Cinemas uses the [Cinemas Online](https://cinemas-online.co.uk/) website to provide data, which has a very nice API. The archiver has been written so that it's very easy to add future cinemas that also use Cinemas Online, without creating a whole new archiver.