### PR TITLE
Add cinema: Scotsman Picturehouse

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Installing this module will install the `showingpreviously` command. This has tw
 - [Empire Cinemas](https://www.empirecinemas.co.uk/) (added 2021-11-07)
 - [Parkway Cinemas](https://parkwaycinemas.co.uk) (added 2021-11-14)
 - [Picturehouse](https://www.picturehouses.com/) (added 2021-11-06)
+- [Scotsman Picturehouse](https://scotsmanpicturehouse.co.uk/) (added 2022-01-10)
 - [The Light Cinemas](https://lightcinemas.co.uk/) (added 2021-10-07)
 - [Vue UK](https://www.myvue.com/) (added 2021-10-31)
 - [Odeon](https://odeon.co.uk/) (added 2021-10-31)

--- a/src/showingpreviously/archiver.py
+++ b/src/showingpreviously/archiver.py
@@ -11,6 +11,7 @@ from showingpreviously.cinemas.dundee_contemporary_arts import DundeeContemporar
 from showingpreviously.cinemas.empire import Empire
 from showingpreviously.cinemas.vista_system import Odeon, Curzon
 from showingpreviously.cinemas.picturehouse import Picturehouse
+from showingpreviously.cinemas.scotsman_picturehouse import ScotsmanPicturehouse
 from showingpreviously.cinemas.lpvs import TheLight
 from showingpreviously.cinemas.parkway import Parkway
 from showingpreviously.cinemas.vue import Vue
@@ -24,6 +25,7 @@ all_cinema_chains = [
     Odeon(),
     Parkway(),
     Picturehouse(),
+    ScotsmanPicturehouse(),
     TheLight(),
     Vue(),
 ]

--- a/src/showingpreviously/cinemas/scotsman_picturehouse.py
+++ b/src/showingpreviously/cinemas/scotsman_picturehouse.py
@@ -1,0 +1,62 @@
+from typing import Iterator
+
+import datetime
+from bs4 import BeautifulSoup
+
+import showingpreviously.requests as requests
+from showingpreviously.model import ChainArchiver, CinemaArchiverException, Chain, Cinema, Screen, Film, Showing
+from showingpreviously.consts import STANDARD_DAYS_AHEAD, UK_TIMEZONE, UNKNOWN_FILM_YEAR
+
+
+FILM_EVENT_URL = 'https://scotsmanpicturehouse.co.uk/wp-admin/admin-ajax.php?action=cal_filter_vista&filter={date}'
+
+CHAIN = Chain('Scotsman Picturehouse')
+CINEMA = Cinema('Scotsman Picturehouse', UK_TIMEZONE)
+SCREEN = Screen('Screen 1')
+
+
+def get_response(url: str) -> requests.Response:
+    r = requests.get(url)
+    if r.status_code != 200:
+        raise CinemaArchiverException(f'Got status code {r.status_code} when fetching URL {url}')
+    return r
+
+
+def get_showing_dates() -> Iterator[datetime.datetime]:
+    current_date = datetime.date.today()
+    end_date = current_date + datetime.timedelta(days=STANDARD_DAYS_AHEAD)
+    while current_date < end_date:
+        yield current_date
+        current_date += datetime.timedelta(days=1)
+
+
+def get_showings_for_date(date: datetime.datetime) -> [Showing]:
+    showings = []
+    date_str = date.strftime('%Y-%m-%d')
+    date_url = FILM_EVENT_URL.format(date=date_str)
+    resp = get_response(date_url)
+    soup = BeautifulSoup(resp.text, 'html.parser')
+    for film_soup in soup.find_all('div', class_='films'):
+        film_name = film_soup['data-movie-filter']
+        film = Film(film_name, UNKNOWN_FILM_YEAR)
+        for showing_soup in film_soup.find_all('div', class_='cinematimes'):
+            showing_time_str = f'{date_str} {showing_soup.text}'
+            showing_time = datetime.datetime.strptime(showing_time_str, '%Y-%m-%d %H:%M')
+            showing = Showing(
+                film=film,
+                time=showing_time,
+                chain=CHAIN,
+                cinema=CINEMA,
+                screen=SCREEN,
+                json_attributes={}
+            )
+            showings.append(showing)
+    return showings
+
+
+class ScotsmanPicturehouse(ChainArchiver):
+    def get_showings(self) -> [Showing]:
+        showings = []
+        for fetch_date in get_showing_dates():
+            showings += get_showings_for_date(fetch_date)
+        return showings


### PR DESCRIPTION
Add the [Scotsman Picturehouse](https://scotsmanpicturehouse.co.uk/) to the archiver. This is a small cinema underneath the [Scotsman Hotel](https://scotsmanhotel.co.uk/) in Edinburgh. The website only exposes the film name and the showing time.

The cinema does not show films every day. Therefore when testing this archiver it may be necessary to increase the number of days beyond `STANDARD_DAYS_AHEAD` so that it actually adds some films to the DB.