### PR TITLE
Add cinema: Dominion Cinema

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Installing this module will install the `showingpreviously` command. This has tw
 
 ## Supported Cinemas
 - [Centre for the Moving Image](https://www.cmi-scotland.co.uk/) ([Filmhouse Edinburgh](https://www.filmhousecinema.com/) and [Belmont Filmhouse](https://www.belmontfilmhouse.com/)) (added 2021-10-30)
-- [Cineworld UK](https://www.cineworld.co.uk/) (added 2021-10-31) 
+- [Cineworld UK](https://www.cineworld.co.uk/) (added 2021-10-31)
+- [Dominion Cinema](https://www.dominioncinema.co.uk/) (added 2022-01-11)
 - [Dundee Contemporary Arts Cinema](https://www.dca.org.uk/whats-on/films) (added 2021-10-29)
 - [Empire Cinemas](https://www.empirecinemas.co.uk/) (added 2021-11-07)
 - [Parkway Cinemas](https://parkwaycinemas.co.uk) (added 2021-11-14)

--- a/src/showingpreviously/archiver.py
+++ b/src/showingpreviously/archiver.py
@@ -7,6 +7,7 @@ from showingpreviously.selenium import close_selenium_webdriver
 # import cinemas here, and add them to the all_cinema_chains list
 from showingpreviously.cinemas.centre_for_the_moving_image import CentreForTheMovingImage
 from showingpreviously.cinemas.cineworld import Cineworld
+from showingpreviously.cinemas.dominion import Dominion
 from showingpreviously.cinemas.dundee_contemporary_arts import DundeeContemporaryArts
 from showingpreviously.cinemas.empire import Empire
 from showingpreviously.cinemas.vista_system import Odeon, Curzon
@@ -19,6 +20,7 @@ all_cinema_chains = [
     CentreForTheMovingImage(),
     Cineworld(),
     Curzon(),
+    Dominion(),
     DundeeContemporaryArts(),
     Empire(),
     Odeon(),

--- a/src/showingpreviously/cinemas/dominion.py
+++ b/src/showingpreviously/cinemas/dominion.py
@@ -1,0 +1,67 @@
+import datetime
+from bs4 import BeautifulSoup
+
+import showingpreviously.requests as requests
+from showingpreviously.model import ChainArchiver, CinemaArchiverException, Chain, Cinema, Screen, Film, Showing
+from showingpreviously.consts import UK_TIMEZONE, UNKNOWN_FILM_YEAR
+
+
+FILM_SCHEDULE_URL = 'https://www.dominioncinema.co.uk/schedule/'
+FILM_NAME_IGNORES = ['(live)']
+
+CHAIN = Chain('Dominion')
+CINEMA = Cinema('Dominion', UK_TIMEZONE)
+
+
+def get_response(url: str) -> requests.Response:
+    r = requests.get(url)
+    if r.status_code != 200:
+        raise CinemaArchiverException(f'Got status code {r.status_code} when fetching URL {url}')
+    return r
+
+
+def format_film_name(film_name: str) -> str:
+    # convert to lowercase for easier processing
+    film_name = film_name.lower()
+    # remove all the ignore items from the film name
+    for ignore_item in FILM_NAME_IGNORES:
+        if ignore_item in film_name:
+            film_name = film_name.replace(ignore_item, '')
+    # tidy up the film name after ignore removal
+    while True:
+        # assume no changes
+        old_name = film_name
+        # remove any double-spaces from removing two items from the title
+        film_name = film_name.replace('  ', ' ').strip()
+        if old_name == film_name:
+            break
+    # return the formatted name
+    return film_name
+
+
+class Dominion(ChainArchiver):
+    def get_showings(self) -> [Showing]:
+        showings = []
+        resp = get_response(FILM_SCHEDULE_URL)
+        soup = BeautifulSoup(resp.text, 'html.parser')
+        schedule_table_body = soup.find('table', class_='schedule').find('tbody')
+        for schedule_item in schedule_table_body.find_all('tr'):
+            showing_date_str = schedule_item.find_all('td')[0].text
+            showing_screen = Screen(schedule_item.find_all('td')[1].text)
+            # 'First Class' is an add-on package, not a separate screen
+            if showing_screen.name == 'First Class and Gold One':
+                showing_screen.name = 'Gold One'
+            film_name = format_film_name(schedule_item.find_all('td')[2].text)
+            film = Film(film_name, UNKNOWN_FILM_YEAR)
+            showing_time_str = schedule_item.find_all('td')[3].find('div', class_='time').text
+            showing_time = datetime.datetime.strptime(f'{showing_time_str} {showing_date_str}', '%H:%M %a %d %b, %Y')
+            showing = Showing(
+                film=film,
+                time=showing_time,
+                chain=CHAIN,
+                cinema=CINEMA,
+                screen=showing_screen,
+                json_attributes={}
+            )
+            showings.append(showing)
+        return showings


### PR DESCRIPTION
Adds the [Dominion Cinema](https://www.dominioncinema.co.uk/) to the archiver. The archiver for the Dominion is very straightforward (around 70 lines of code) because the Dominion provides a [schedule]() page listing all the showings.

Some notes about this archiver:
1. The Dominion has a special designation for showings called *First Class* that includes pre-showing drinks at a dedicated bar. I have not assigned an attribute for this, but can if it would be useful?
2. From a sample size of one (the showing of *Royal Ballet: Romeo and Juliet (Live)* on Valentine's Day) I believe that live events have `(Live)` in the film title. Accordingly, the archiver will strip out `(live)` from the title and add `live` to the `format` attribute list.
3. Beyond what is mentioned above, the Dominion does not expose any attributes about showings, nor does it expose the release year of films.
4. The archiver returns all showings, regardless of how their showing date/time falls in relation to `STANDARD_DAYS_AHEAD`. I am working on a PR to the main archiver to filter out showings outwith this range.