### PR TITLE
Fix picturehouse sub/dub attributes

### DIFF
--- a/ATTRIBUTES.md
+++ b/ATTRIBUTES.md
@@ -18,4 +18,4 @@ the string language (eg. `english`), and if not, this is simply `True`
 - `senior`: bool, specifies if this showing is for senior citizens only
 - `subtitled`: string or bool, specifies if the film is subtitled. If the language of the subtitling is known, this is
 the string language (eg. `english`), and if not, this is simply `True`
-
+- `kids`: this film is for kids, and adults must be accompanying a child

--- a/src/showingpreviously/cinemas/picturehouse.py
+++ b/src/showingpreviously/cinemas/picturehouse.py
@@ -21,7 +21,7 @@ LARAVEL_PATTERN = re.compile(r'laravel_session=(?P<laravel_session>.+?);')
 SHOWING_URL_ID_PATTERN = re.compile(r'/movie-details/\d+/(?P<film_id>.+?)/(?P<slug>.+)')
 SLUG_YEAR_PATTERN = re.compile(r'(?P<year>(?:18|19|20)\d{2})')
 JS_TO_URL_PATTERN = re.compile(r'"(?P<film_link>https?://.+?)"')
-DUBBED_LANGUAGE_PATTERN = re.compile(r'Please note, this screening features the (?P<dub_language>.+?) version of the film')
+DUBBED_LANGUAGE_PATTERN = re.compile(r'Please note, this screening features the Dubbed (?P<dub_language>.+?) version of the film')
 SUBBED_LANGUAGE_PATTERN = re.compile(r'have (?P<sub_language>.+?) subtitles')
 
 

--- a/src/showingpreviously/cinemas/picturehouse.py
+++ b/src/showingpreviously/cinemas/picturehouse.py
@@ -75,7 +75,7 @@ def get_film_year(film_link: str) -> str:
     soup = BeautifulSoup(r.text, features='html.parser')
     metadata = soup.find('div', {'class': 'directorDiv'})
     if not metadata:
-        return ''
+        return UNKNOWN_FILM_YEAR
     date = metadata.find('li', text='Release Date :').findNext('li').text
     year = date[-4:]
     return year

--- a/src/showingpreviously/cinemas/picturehouse.py
+++ b/src/showingpreviously/cinemas/picturehouse.py
@@ -21,6 +21,8 @@ LARAVEL_PATTERN = re.compile(r'laravel_session=(?P<laravel_session>.+?);')
 SHOWING_URL_ID_PATTERN = re.compile(r'/movie-details/\d+/(?P<film_id>.+?)/(?P<slug>.+)')
 SLUG_YEAR_PATTERN = re.compile(r'(?P<year>(?:18|19|20)\d{2})')
 JS_TO_URL_PATTERN = re.compile(r'"(?P<film_link>https?://.+?)"')
+DUBBED_LANGUAGE_PATTERN = re.compile(r'Please note, this screening features the (?P<dub_language>.+?) version of the film')
+SUBBED_LANGUAGE_PATTERN = re.compile(r'have (?P<sub_language>.+?) subtitles')
 
 
 def get_showing_dates() -> str:
@@ -72,6 +74,8 @@ def get_film_year(film_link: str) -> str:
 
     soup = BeautifulSoup(r.text, features='html.parser')
     metadata = soup.find('div', {'class': 'directorDiv'})
+    if not metadata:
+        return ''
     date = metadata.find('li', text='Release Date :').findNext('li').text
     year = date[-4:]
     return year
@@ -113,6 +117,13 @@ def get_attributes(attributes: [dict[str, any]]) -> dict[str, any]:
             json_attributes['ad-trailer-free'] = True
         elif attribute['attribute'] == 'Sub Cinema':
             json_attributes['subtitled'] = True
+            language = SUBBED_LANGUAGE_PATTERN.search(attribute['description'])
+            if language:
+                json_attributes['subtitled'] = language.group('sub_language')
+        elif attribute['attribute'] == 'Dub Cinema':
+            language = DUBBED_LANGUAGE_PATTERN.search(attribute['description'])
+            if language:
+                json_attributes['language'] = language.group('dub_language')
         elif attribute['attribute'] == 'LiveSat':
             json_attributes['format'].append('Live')
         elif attribute['attribute'] == 'Audio D':
@@ -125,6 +136,8 @@ def get_attributes(attributes: [dict[str, any]]) -> dict[str, any]:
             json_attributes['format'].append('4K')
         elif attribute['attribute'] == 'Toddler Ti':
             json_attributes['carers-and-babies'] = True
+        elif attribute['attribute'] == "Kids' Club":
+            json_attributes['kids'] = True
     if len(json_attributes['format']) == 0:
         del json_attributes['format']
     return json_attributes


### PR DESCRIPTION
- Add the subtitle language for showings, when it can be worked out.
- When a film is dubbed, add the dubbed language to the `language` attribute, if it can be worked out
- Add a `kids` attribute for the Kids Club (where adults must be accompanying a child)