### PR TITLE
fix DCA: ignore all non-cinema events

### DIFF
--- a/src/showingpreviously/cinemas/dundee_contemporary_arts.py
+++ b/src/showingpreviously/cinemas/dundee_contemporary_arts.py
@@ -41,9 +41,13 @@ def get_film_links_from_index(index_url: str) -> Iterator[str]:
     main_content = soup.find('div', {'id': 'content-main'})
     if not main_content:
         raise CinemaArchiverException(f'Could not get main content of URL {index_url}')
-    for film_title in main_content.find_all('h2'):
-        link = film_title.find('a', href=True)
-        yield link['href']
+    for film_item in main_content.find_all('div', {'class': 'article event'}):
+        film_title = film_item.find('h2')
+        link_location = film_title.find('a', href=True)['href']
+        location = film_item.find('p', {'class': 'location'}).text
+        if location.strip().lower() != 'cinema':
+            continue
+        yield link_location
 
 
 def get_film_info_from_url(film_url: str) -> (str, str, str, dict[str, any]):


### PR DESCRIPTION
Some DCA events listed are non-cinema events, for example [DCA at home](https://www.dca.org.uk/whats-on/event/dca-at-home-film-library), which obviously crashes the archiver as it does not have a showtime, screen, booking link, etc.

This PR filters the results to only archive those events that have their location as "Cinema"