### PR TITLE
feat: update readme to include installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,21 @@ An archiver of cinema movie showtimes
 
 A program to archive showtimes of movies in cinemas, to create a historical record of what movies showed when and where.
 
+## Installation
+1. Clone the repo:
+   * `git clone https://github.com/davidferguson/ShowingPreviously.git`
+   * `cd ShowingPreviously/`
+2. Setup a Python3 virtual environment (python3.8+ required):
+   * `python3 -m venv venv`
+   * `source venv/bin/activate`
+3. Install ShowingPreviously:
+   * `python setup.py install`
+4. Install Chromedriver/Geckodriver:
+   * Download Chromedriver/Geckodriver **for the version of Chrome/Firefox you have installed**:
+      * Download Geckodriver from https://github.com/mozilla/geckodriver/releases
+      * Download Chromedriver from https://chromedriver.chromium.org/downloads
+   * Add the downloaded binary to your PATH
+
 ## Usage
 Installing this module will install the `showingpreviously` command. This has two sub-commands:
 1. `showingpreviously info`: Prints info about the program, and basic info about what is stored in the database


### PR DESCRIPTION
Update README to include installation instructions. This includes installation of `showingpreviously` as well as chromedriver/geckodriver, which is required for Vista Systems (and maybe more in the future).