### PR TITLE
CLI: Add "--dummy-run" option to not make any changes to DB

### DIFF
--- a/src/showingpreviously/archiver.py
+++ b/src/showingpreviously/archiver.py
@@ -29,7 +29,7 @@ all_cinema_chains = [
 ]
 
 
-def process_showing(showing: Showing, dry_run: bool):
+def process_showing(showing: Showing, dry_run: bool = False):
     film = showing.film
     time = showing.time
     chain = showing.chain
@@ -48,19 +48,19 @@ def process_showing(showing: Showing, dry_run: bool):
         add_showing(film.name, film.year, chain.name, cinema.name, screen.name, utc_time, json_attributes)
 
 
-def run_chain(chain: ChainArchiver, dry_run: bool):
+def run_chain(chain: ChainArchiver, dry_run: bool = False):
     showings = chain.get_showings()
     for showing in showings:
         process_showing(showing, dry_run)
 
 
-def run_all(dry_run: bool) -> None:
+def run_all(dry_run: bool = False) -> None:
     for cinema_chain in all_cinema_chains:
         run_chain(cinema_chain, dry_run)
     close_selenium_webdriver()
 
 
-def run_single(name: str, dry_run: bool) -> None:
+def run_single(name: str, dry_run: bool = False) -> None:
     for cinema_chain in all_cinema_chains:
         if type(cinema_chain).__name__ == name:
             run_chain(cinema_chain, dry_run)

--- a/src/showingpreviously/archiver.py
+++ b/src/showingpreviously/archiver.py
@@ -29,7 +29,7 @@ all_cinema_chains = [
 ]
 
 
-def process_showing(showing: Showing):
+def process_showing(showing: Showing, dummy_run: bool):
     film = showing.film
     time = showing.time
     chain = showing.chain
@@ -40,27 +40,28 @@ def process_showing(showing: Showing):
     timezone = pytz.timezone(cinema.timezone)
     utc_time = timezone.localize(time).astimezone(pytz.timezone('UTC'))
 
-    add_chain(chain.name)
-    add_cinema(chain.name, cinema.name, cinema.timezone)
-    add_screen(chain.name, cinema.name, screen.name)
-    add_film(film.name, film.year)
-    add_showing(film.name, film.year, chain.name, cinema.name, screen.name, utc_time, json_attributes)
+    if not dummy_run:
+        add_chain(chain.name)
+        add_cinema(chain.name, cinema.name, cinema.timezone)
+        add_screen(chain.name, cinema.name, screen.name)
+        add_film(film.name, film.year)
+        add_showing(film.name, film.year, chain.name, cinema.name, screen.name, utc_time, json_attributes)
 
 
-def run_chain(chain: ChainArchiver):
+def run_chain(chain: ChainArchiver, dummy_run: bool):
     showings = chain.get_showings()
     for showing in showings:
-        process_showing(showing)
+        process_showing(showing, dummy_run)
 
 
-def run_all() -> None:
+def run_all(dummy_run: bool) -> None:
     for cinema_chain in all_cinema_chains:
-        run_chain(cinema_chain)
+        run_chain(cinema_chain, dummy_run)
     close_selenium_webdriver()
 
 
-def run_single(name: str) -> None:
+def run_single(name: str, dummy_run: bool) -> None:
     for cinema_chain in all_cinema_chains:
         if type(cinema_chain).__name__ == name:
-            run_chain(cinema_chain)
+            run_chain(cinema_chain, dummy_run)
     close_selenium_webdriver()

--- a/src/showingpreviously/archiver.py
+++ b/src/showingpreviously/archiver.py
@@ -29,7 +29,7 @@ all_cinema_chains = [
 ]
 
 
-def process_showing(showing: Showing, dummy_run: bool):
+def process_showing(showing: Showing, dry_run: bool):
     film = showing.film
     time = showing.time
     chain = showing.chain
@@ -40,7 +40,7 @@ def process_showing(showing: Showing, dummy_run: bool):
     timezone = pytz.timezone(cinema.timezone)
     utc_time = timezone.localize(time).astimezone(pytz.timezone('UTC'))
 
-    if not dummy_run:
+    if not dry_run:
         add_chain(chain.name)
         add_cinema(chain.name, cinema.name, cinema.timezone)
         add_screen(chain.name, cinema.name, screen.name)
@@ -48,20 +48,20 @@ def process_showing(showing: Showing, dummy_run: bool):
         add_showing(film.name, film.year, chain.name, cinema.name, screen.name, utc_time, json_attributes)
 
 
-def run_chain(chain: ChainArchiver, dummy_run: bool):
+def run_chain(chain: ChainArchiver, dry_run: bool):
     showings = chain.get_showings()
     for showing in showings:
-        process_showing(showing, dummy_run)
+        process_showing(showing, dry_run)
 
 
-def run_all(dummy_run: bool) -> None:
+def run_all(dry_run: bool) -> None:
     for cinema_chain in all_cinema_chains:
-        run_chain(cinema_chain, dummy_run)
+        run_chain(cinema_chain, dry_run)
     close_selenium_webdriver()
 
 
-def run_single(name: str, dummy_run: bool) -> None:
+def run_single(name: str, dry_run: bool) -> None:
     for cinema_chain in all_cinema_chains:
         if type(cinema_chain).__name__ == name:
-            run_chain(cinema_chain, dummy_run)
+            run_chain(cinema_chain, dry_run)
     close_selenium_webdriver()

--- a/src/showingpreviously/cli.py
+++ b/src/showingpreviously/cli.py
@@ -27,15 +27,18 @@ def info_cmd(list_chains: bool) -> None:
 
 @cli.command('run')
 @click.option('--chain', default=None, show_default=True, type=click.STRING, help='The archiver class name to run')
-def run_cmd(chain: Optional[str]) -> None:
+@click.option('--dummy-run', 'dummy_run', is_flag=True, default=False, show_default=False, type=click.BOOL, help='Run, but don\'t make any changes to the DB')
+def run_cmd(chain: Optional[str], dummy_run: bool) -> None:
     """Runs the archiver on all cinema chains"""
+    if dummy_run:
+        print("Dummy run, no changes to DB")
     if chain is None:
-        run_all()
+        run_all(dummy_run)
     else:
         installed_chains = [type(cinema_chain).__name__ for cinema_chain in all_cinema_chains]
         if chain not in installed_chains:
             raise click.BadOptionUsage('--chain', f'No such installed chain "{chain}"')
-        run_single(chain)
+        run_single(chain, dummy_run)
 
 
 if __name__ == '__main__':

--- a/src/showingpreviously/cli.py
+++ b/src/showingpreviously/cli.py
@@ -27,18 +27,18 @@ def info_cmd(list_chains: bool) -> None:
 
 @cli.command('run')
 @click.option('--chain', default=None, show_default=True, type=click.STRING, help='The archiver class name to run')
-@click.option('--dummy-run', 'dummy_run', is_flag=True, default=False, show_default=False, type=click.BOOL, help='Run, but don\'t make any changes to the DB')
-def run_cmd(chain: Optional[str], dummy_run: bool) -> None:
+@click.option('--dry-run', 'dry_run', is_flag=True, default=False, show_default=False, type=click.BOOL, help='Run, but don\'t make any changes to the DB')
+def run_cmd(chain: Optional[str], dry_run: bool) -> None:
     """Runs the archiver on all cinema chains"""
-    if dummy_run:
-        print("Dummy run, no changes to DB")
+    if dry_run:
+        print('Dry run, no changes to DB')
     if chain is None:
-        run_all(dummy_run)
+        run_all(dry_run)
     else:
         installed_chains = [type(cinema_chain).__name__ for cinema_chain in all_cinema_chains]
         if chain not in installed_chains:
             raise click.BadOptionUsage('--chain', f'No such installed chain "{chain}"')
-        run_single(chain, dummy_run)
+        run_single(chain, dry_run)
 
 
 if __name__ == '__main__':

--- a/src/showingpreviously/cli.py
+++ b/src/showingpreviously/cli.py
@@ -28,7 +28,7 @@ def info_cmd(list_chains: bool) -> None:
 @cli.command('run')
 @click.option('--chain', default=None, show_default=True, type=click.STRING, help='The archiver class name to run')
 @click.option('--dry-run', 'dry_run', is_flag=True, default=False, show_default=False, type=click.BOOL, help='Run, but don\'t make any changes to the DB')
-def run_cmd(chain: Optional[str], dry_run: bool) -> None:
+def run_cmd(chain: Optional[str], dry_run: bool = False) -> None:
     """Runs the archiver on all cinema chains"""
     if dry_run:
         print('Dry run, no changes to DB')


### PR DESCRIPTION
The `--dummy-run` option runs the archiver as normal, but does not
save any of the results into the DB. This is useful in a number of
circumstances:

1. Development: during development it is essential to know that
   the code compiles and runs without errors, but before this is
   known, having partial or incomplete results saved in the DB
   is undesirable.
2. Testing: automated checks to ensure that there have been no
   breaking API changes are desirable, but such tests should not
   change a DB.

Remaining issues: the URL log that maintains a list of URLs that
have been accessed to perform the archiving is not affected by the
status of the `--dummy-run` flag. This is undesirable, however I
am not sure what the most elegent solution to fixing this would be.
