### PR TITLE
Consts: allow the webdriver order to be configured

### DIFF
--- a/src/showingpreviously/consts.py
+++ b/src/showingpreviously/consts.py
@@ -19,3 +19,6 @@ UNKNOWN_FILM_YEAR = ''
 # archiver consts
 STANDARD_DAYS_AHEAD = 2
 UK_TIMEZONE = 'Europe/London'
+
+# webdriver consts
+WEBDRIVER_ORDER = ['Firefox', 'Chrome']

--- a/src/showingpreviously/selenium.py
+++ b/src/showingpreviously/selenium.py
@@ -5,6 +5,9 @@ from selenium.webdriver.remote.webdriver import WebDriver
 
 from typing import Optional
 
+from showingpreviously.consts import WEBDRIVER_ORDER
+from showingpreviously.model import CinemaArchiverException
+
 
 WEBDRIVER: Optional[WebDriver] = None
 
@@ -12,17 +15,28 @@ WEBDRIVER: Optional[WebDriver] = None
 def get_selenium_webdriver() -> WebDriver:
     global WEBDRIVER
     if WEBDRIVER is None:
-        try:
-            chrome_options = ChromeOptions()
-            # running headless will stop cloudflare from working
-            # chrome_options.headless = True
-            WEBDRIVER = webdriver.Chrome(options=chrome_options)
-        except common.exceptions.WebDriverException:
-            firefox_options = FirefoxOptions()
-            # running headless will stop cloudflare from working
-            # firefox_options.headless = True
-            WEBDRIVER = webdriver.Firefox(options=firefox_options)
-    return WEBDRIVER
+        for i, webdriver_name in enumerate(WEBDRIVER_ORDER):
+            try:
+                WEBDRIVER = get_specific_webdriver(webdriver_name)
+                return WEBDRIVER
+            except common.exceptions.WebDriverException as e:
+                pass
+        raise CinemaArchiverException("No available webdriver found")
+
+
+def get_specific_webdriver(webdriver_name: str) -> WebDriver:
+    if webdriver_name == 'Firefox':
+        firefox_options = FirefoxOptions()
+        # running headless will stop cloudflare from working
+        # firefox_options.headless = True
+        return webdriver.Firefox(options=firefox_options)
+    elif webdriver_name == 'Chrome':
+        chrome_options = ChromeOptions()
+        # running headless will stop cloudflare from working
+        # chrome_options.headless = True
+        return webdriver.Chrome(options=chrome_options)
+    else:
+        raise CinemaArchiverException(f'Unknown webdriver name: {webdriver_name}')
 
 
 def close_selenium_webdriver() -> None:


### PR DESCRIPTION
Allow the selection and preference of the webdriver (currently used just for Vista Systems - Odeon, Curzon - but likely more in the future) to be user configurable.

Two webdrivers, Chrome and Firefox, are implemented currently, and the default configuration in `consts.py` is to attempt to use Firefox first, and then try Chrome if Firefox is not available.

If none of the given webdrivers are available, a CinemaArchiverException is thrown.